### PR TITLE
fix:allow workshop 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pywikihow>=0.5.7
-ovos_workshop>=0.0.12,<3.0.0
+ovos_workshop>=0.0.12,<4.0.0
 quebra-frases


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `ovos_workshop` package, allowing for a broader range of compatible versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->