### PR TITLE
Add French WikiHow locale

### DIFF
--- a/locale/fr-fr/MiscBlacklist.voc
+++ b/locale/fr-fr/MiscBlacklist.voc
@@ -1,0 +1,9 @@
+peux-tu
+explique
+comment
+combien de temps
+installer
+est-ce
+skills
+quelle heure
+tu fais

--- a/locale/fr-fr/MiscBlacklist.voc
+++ b/locale/fr-fr/MiscBlacklist.voc
@@ -1,9 +1,5 @@
-peux-tu
-explique
-comment
-combien de temps
-installer
-est-ce
-skills
-quelle heure
-tu fais
+que peux-tu faire
+quelles compétences sont disponibles
+installer une compétence
+installer des compétences
+quelle heure est-il

--- a/locale/fr-fr/Weather.voc
+++ b/locale/fr-fr/Weather.voc
@@ -1,2 +1,3 @@
-météo
-temps
+quel temps fait-il
+quelle est la météo
+météo actuelle

--- a/locale/fr-fr/Weather.voc
+++ b/locale/fr-fr/Weather.voc
@@ -1,0 +1,2 @@
+météo
+temps

--- a/locale/fr-fr/howto.failure.dialog
+++ b/locale/fr-fr/howto.failure.dialog
@@ -1,2 +1,2 @@
-Je ne suis pas sûr.
-Je n'ai rien trouvé sur WikiHow.
+Je n'ai rien trouvé sur WikiHow pour ça.
+Je n'ai pas trouvé d'article WikiHow correspondant.

--- a/locale/fr-fr/howto.failure.dialog
+++ b/locale/fr-fr/howto.failure.dialog
@@ -1,0 +1,2 @@
+Je ne suis pas sûr.
+Je n'ai rien trouvé sur WikiHow.

--- a/locale/fr-fr/howto.intent
+++ b/locale/fr-fr/howto.intent
@@ -1,0 +1,5 @@
+explique-moi étape par étape {query}
+comment faire {query}
+comment puis-je {query}
+comment {query}
+étapes pour {query}

--- a/locale/fr-fr/howto.intent
+++ b/locale/fr-fr/howto.intent
@@ -1,5 +1,5 @@
 explique-moi étape par étape {query}
 comment faire {query}
 comment puis-je {query}
-comment {query}
+comment faire pour {query}
 étapes pour {query}

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -2,10 +2,10 @@
   "skill_id": "ovos-skill-wikihow.openvoiceos",
   "source": "https://github.com/OpenVoiceOS/ovos-skill-wikihow",
   "name": "WikiHow",
-  "description": "Comment faire presque n'importe quoi.",
+  "description": "Des explications étape par étape pour les questions pratiques du quotidien.",
   "examples": [
-    "Comment faire cuire un oeuf",
-    "Comment faire pour que mon chien arrête d'aboyer"
+    "Comment faire cuire un oeuf dur ?",
+    "Comment faire pour que mon chien arrête d'aboyer ?"
   ],
   "tags": [
     "quotidien",

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,0 +1,14 @@
+{
+  "skill_id": "ovos-skill-wikihow.openvoiceos",
+  "source": "https://github.com/OpenVoiceOS/ovos-skill-wikihow",
+  "name": "WikiHow",
+  "description": "Comment faire presque n'importe quoi.",
+  "examples": [
+    "Comment faire cuire un oeuf",
+    "Comment faire pour que mon chien arrête d'aboyer"
+  ],
+  "tags": [
+    "quotidien",
+    "information"
+  ]
+}

--- a/locale/fr-fr/step.dialog
+++ b/locale/fr-fr/step.dialog
@@ -1,0 +1,1 @@
+Étape {number}, {step}

--- a/locale/fr-fr/wikihow.intent
+++ b/locale/fr-fr/wikihow.intent
@@ -1,4 +1,4 @@
+cherche {query} sur WikiHow
 cherche sur WikiHow {query}
-cherche sur wikihow {query}
-que dit WikiHow sur {query}
-que dit wikihow sur {query}
+que dit l'article WikiHow sur {query}
+montre-moi l'article WikiHow sur {query}

--- a/locale/fr-fr/wikihow.intent
+++ b/locale/fr-fr/wikihow.intent
@@ -1,0 +1,4 @@
+cherche sur WikiHow {query}
+cherche sur wikihow {query}
+que dit WikiHow sur {query}
+que dit wikihow sur {query}


### PR DESCRIPTION
## Summary
- add a complete French locale tree for WikiHow prompts, intents, and metadata
- keep the tutorial phrasing natural for spoken how-to requests

## Validation
- verified fr-fr file coverage against locale/en-us
- validated locale/fr-fr/skill.json parses as JSON