### PR TITLE
fix: allow ovos-workshop 9.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pywikihow>=0.5.7
-ovos-workshop>=8.0.0,<9.0.0
+ovos-workshop>=8.0.0,<10.0.0
 quebra-frases

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
             'pytest',
             'pytest-timeout',
             'ovoscope>=1.0.1a1',
-            'ovos-workshop>=8.3.0a1,<9.0.0',
+            'ovos-workshop>=8.3.0a1,<10.0.0',
             'ovos-adapt-parser>=1.6.0a1,<2.0.0',
             'ovos-padatious>=1.1.0a1,<2.0.0',
         ]


### PR DESCRIPTION
ovos-core 2.5.0a2 requires `ovos-workshop>=9.0.2a1`; this repo's `<9.0.0` cap is one of 24 blocking the auto-generated constraints-alpha from resolving latest workshop (caught by raspOVOS's new Tier 2 `pip check` gate, which found shipped images with a broken dep graph). Cap bumped to `<10.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)