### PR TITLE
fix: subscribe e2e tests to the canonical (unsuffixed) intent topic

### DIFF
--- a/test/end2end/test_intents_en_us.py
+++ b/test/end2end/test_intents_en_us.py
@@ -10,6 +10,7 @@ from unittest import TestCase
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session
+from ovos_spec_tools import canonical_intent_topic
 from ovoscope import get_minicroft
 
 SKILL_ID = "ovos-skill-wikihow.openvoiceos"
@@ -40,7 +41,12 @@ class _RoutingTest(TestCase):
         """Emit ``utterance`` and collect the intent + speak messages it yields."""
         intents = []
         spoken = []
-        self.bus.on(f"{SKILL_ID}:wikihow.intent",
+        # ovos-workshop dispatches intent handlers on the canonical topic
+        # (".intent" suffix stripped) since 9.3.13a1 - mirror the same
+        # canonicalization the skill's register_intent_file uses so this
+        # listener tracks the real contract instead of a hardcoded guess.
+        canonical_topic = canonical_intent_topic(f"{SKILL_ID}:wikihow.intent")
+        self.bus.on(canonical_topic,
                     lambda m: intents.append(("wikihow.intent", m.data.get("query"))))
         self.bus.on("speak",
                     lambda m: spoken.append(m.data.get("utterance", "")))


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Since ovos-workshop 9.3.13a1, `register_intent_file` canonicalizes the bus topic it dispatches intent matches on: it calls `ovos_spec_tools.canonical_intent_topic`, which strips the trailing `.intent` suffix. So a skill registered as `wikihow.intent` now dispatches on `SKILL_ID:wikihow`, not `SKILL_ID:wikihow.intent`.

`test/end2end/test_intents_en_us.py`'s `_run()` helper was still subscribing to the old literal `f"{SKILL_ID}:wikihow.intent"` topic, so the listener never fired, the `intents` list stayed empty, and all three `TestWikiHowIntentRouting` tests failed their `assertIn` checks deterministically against current latest alphas. CI evidence showed the actual dispatched match as `IntentHandlerMatch(match_type='ovos-skill-wikihow.openvoiceos:wikihow', ...)`, confirming the canonicalized topic.

The fix imports and calls the real `canonical_intent_topic` from `ovos_spec_tools` (the same function workshop's `register_intent_file` uses internally) to compute the listener topic, instead of hardcoding or hand-stripping the suffix, so the test tracks the actual contract rather than a guess. `test/end2end/test_golden_utterances.py` already strips the suffix generically for its own comparison and needed no change.

Red before the fix: `test/end2end/test_intents_en_us.py::TestWikiHowIntentRouting` — 3 failed (`test_search_wikihow_for_topic`, `test_find_topic_on_wikihow`, `test_what_does_wikihow_say_about_topic`). Green after: same 3 tests pass, and the full `test/end2end/` suite passes 15/15 across two consecutive runs with no flakiness.

PR #88's ovoscope job is red solely because of this same bug and will be rebased onto this fix once it merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WikiHow intent handling in end-to-end tests by ensuring intent topics match the skill’s dispatch format.
  * Improved test reliability for WikiHow intent listener registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->