### PR TITLE
fix: match polite how-to openers in howto.intent

### DIFF
--- a/locale/en-US/howto.intent
+++ b/locale/en-US/howto.intent
@@ -3,3 +3,7 @@
 (how to|show me how to|tell me how to) {query}
 (steps|instructions) (for|to) {query}
 what are the steps (for|to) {query}
+(can|could) you [please] tell me how to {query}
+(can|could) you [please] explain how to {query}
+[please] show me how to {query}
+i (want|need) to (know|learn) how to {query}

--- a/test/unittests/test_skill.py
+++ b/test/unittests/test_skill.py
@@ -29,6 +29,24 @@ class TestExtractKeyword(unittest.TestCase):
         self.assertEqual(skill.extract_keyword("how do i make coffee", "en-US"),
                          "make coffee")
 
+    def test_extracts_query_from_polite_how_to_openers(self):
+        # OpenVoiceOS/ovos-skill-wikihow#92: polite openers like "could you
+        # please tell me how to X" fell through un-anchored, so the CQ
+        # keyword extractor never even considered them.
+        skill = _make_skill()
+        for utterance, expected in [
+            ("could you please tell me how to boil an egg", "boil an egg"),
+            ("can you tell me how to boil an egg", "boil an egg"),
+            ("can you explain how to tie a tie", "tie a tie"),
+            ("could you please explain how to tie a tie", "tie a tie"),
+            ("please show me how to boil an egg", "boil an egg"),
+            ("show me how to boil an egg", "boil an egg"),
+            ("i want to know how to boil an egg", "boil an egg"),
+            ("i need to learn how to tie a tie", "tie a tie"),
+        ]:
+            self.assertEqual(skill.extract_keyword(utterance, "en-US"), expected,
+                             f"failed to extract query from: {utterance!r}")
+
 
 class TestHandleIntent(unittest.TestCase):
     def test_missing_result_speaks_failure(self):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Fixes #92

Polite phrasings like "could you please tell me how to boil an egg" or "can you explain how to tie a tie" fell through the CQ keyword extractor's `howto.intent` templates unmatched, so wikihow silently withdrew from common-query arbitration for these utterances even though it had a real answer. This adds four template lines to `locale/en-US/howto.intent`, verbatim as proposed in the issue: `(can|could) you [please] tell me how to {query}`, `(can|could) you [please] explain how to {query}`, `[please] show me how to {query}`, and `i (want|need) to (know|learn) how to {query}`.

I verified the additions against the actual expansion path the skill uses at runtime (`WikiHowSkill.register_kw_xtract`, which runs each bracketed line through `padacioso.expand()` before handing the expanded literal samples to `IntentContainer`) rather than against raw bracket syntax fed straight to the matcher — the two behave differently for adjacent alternation-then-optional groups, and only the actual code path matters. All 8 phrasing variants from the issue extract the correct `{query}` slot through that path.

Step-navigation intents ("what's the next step", "repeat the last step") mentioned in the issue are explicitly out of scope here; the issue itself flags that a handler read is needed before proposing anything there, and this PR does not attempt it.

`howto.intent` only feeds the skill's internal common-query keyword extractor (`extract_keyword`), not a directly registered padatious/padacioso intent, so the shared golden-utterance suite's `_PIPELINE` (padatious/padacioso only, no common-query) can't exercise it — adding rows there would silently no-op. Regression coverage instead extends `test/unittests/test_skill.py::TestExtractKeyword` with a new test covering all 8 phrasings, calling `extract_keyword` the same way `match_common_query` does. That test fails with `AssertionError: None != 'boil an egg'` against the unfixed `howto.intent` and passes after the fix. The full local suite (7 unit tests + 18 end2end tests, including the existing common-query arbitration suite) passes with no regressions.