### PR TITLE
feat: pt-BR, nl-NL, sv-SE, kab locale parity

### DIFF
--- a/locale/kab/howto.failure.dialog
+++ b/locale/kab/howto.failure.dialog
@@ -1,0 +1,3 @@
+ur zriɣ ara akken iwata
+ur ẓriɣ ara
+ɛerḍeɣ ad nadiɣ deg wikihow maca ur ufiɣ acemma

--- a/locale/kab/howto.intent
+++ b/locale/kab/howto.intent
@@ -1,0 +1,9 @@
+(fesser|) yal akkud {query}
+(amek zemreɣ|amek ilaq) ad {query}
+(amek|sken-iyi amek|ini-yi amek) ad {query}
+(ikuten|iwellihen) i {query}
+d acu-tent ikuten i {query}
+(zemreḍ|tzemreḍ) [ma ulac aɣilif] ad iyi-tiniḍ amek ad {query}
+(zemreḍ|tzemreḍ) [ma ulac aɣilif] ad tesferseḍ amek ad {query}
+[ma ulac aɣilif] sken-iyi amek ad {query}
+bɣiɣ ad (ẓreɣ|lemdeɣ) amek ad {query}

--- a/locale/kab/misc_blacklist.voc
+++ b/locale/kab/misc_blacklist.voc
@@ -1,0 +1,8 @@
+tzemreḍ
+fesser
+acḥal n wakud
+sbadu
+d acu-t
+tuffɣin
+d acḥal usrag
+txeddmeḍ

--- a/locale/kab/query.blacklist
+++ b/locale/kab/query.blacklist
@@ -1,0 +1,2 @@
+(wagi|wagla|tigi|widak|yiwen)
+(netta|nettat|nutni|nutenti)

--- a/locale/kab/skill.json
+++ b/locale/kab/skill.json
@@ -1,0 +1,13 @@
+{
+  "skill_id": "ovos-skill-wikihow.openvoiceos",
+  "source": "https://github.com/OpenVoiceOS/ovos-skill-wikihow",
+  "name": "WikiHow",
+  "description": "Amek ara nexdem qrib kullec.",
+  "examples": [
+    "amek ara nsellew tamellalt",
+    "amek ara sḥebseɣ aqjun-inu ad yeqqar"
+  ],
+  "tags": [
+    "n wass", "talɣut"
+  ]
+}

--- a/locale/kab/step.dialog
+++ b/locale/kab/step.dialog
@@ -1,0 +1,1 @@
+Akud {number}, {step}

--- a/locale/kab/weather.voc
+++ b/locale/kab/weather.voc
@@ -1,0 +1,2 @@
+tanezmert n waqas
+aqas

--- a/locale/kab/wikihow.blacklist
+++ b/locale/kab/wikihow.blacklist
@@ -1,0 +1,1 @@
+<weather>

--- a/locale/kab/wikihow.intent
+++ b/locale/kab/wikihow.intent
@@ -1,0 +1,3 @@
+(nadi|sizzeg|af) {query} deg (wiki how|wikihow)
+nadi deg (wiki how|wikihow) (ɣef|) {query}
+d acu i d-yenna (wiki how|wikihow) ɣef {query}

--- a/locale/nl-NL/howto.failure.dialog
+++ b/locale/nl-NL/howto.failure.dialog
@@ -1,0 +1,3 @@
+ik weet het niet zeker
+ik weet het niet
+ik heb op wikihow gezocht maar kon niets vinden

--- a/locale/nl-NL/howto.intent
+++ b/locale/nl-NL/howto.intent
@@ -1,0 +1,9 @@
+(leg uit|) stap voor stap {query}
+(hoe kan|moet|zou) ik {query}
+(hoe|laat me zien hoe|vertel me hoe) ik {query}
+(stappen|instructies) om {query}
+wat zijn de stappen om {query}
+(kun|zou) je [alsjeblieft] me vertellen hoe ik {query}
+(kun|zou) je [alsjeblieft] uitleggen hoe ik {query}
+[alsjeblieft] laat me zien hoe ik {query}
+ik (wil|moet) weten hoe ik {query}

--- a/locale/nl-NL/misc_blacklist.voc
+++ b/locale/nl-NL/misc_blacklist.voc
@@ -1,0 +1,8 @@
+kun je
+uitleggen
+hoe lang
+installeren
+is het
+vaardigheden
+hoe laat
+doe je

--- a/locale/nl-NL/query.blacklist
+++ b/locale/nl-NL/query.blacklist
@@ -1,0 +1,2 @@
+(het|dit|dat|deze|die|een)
+(hij|zij|ze|hem|haar|hen|zijn|hun)

--- a/locale/nl-NL/skill.json
+++ b/locale/nl-NL/skill.json
@@ -1,0 +1,13 @@
+{
+  "skill_id": "ovos-skill-wikihow.openvoiceos",
+  "source": "https://github.com/OpenVoiceOS/ovos-skill-wikihow",
+  "name": "WikiHow",
+  "description": "Hoe je bijna alles doet.",
+  "examples": [
+    "hoe kook je een ei",
+    "hoe zorg ik dat mijn hond stopt met blaffen"
+  ],
+  "tags": [
+    "dagelijks", "informatie"
+  ]
+}

--- a/locale/nl-NL/step.dialog
+++ b/locale/nl-NL/step.dialog
@@ -1,0 +1,1 @@
+Stap {number}, {step}

--- a/locale/nl-NL/weather.voc
+++ b/locale/nl-NL/weather.voc
@@ -1,0 +1,2 @@
+meteorologie
+weer

--- a/locale/nl-NL/wikihow.blacklist
+++ b/locale/nl-NL/wikihow.blacklist
@@ -1,0 +1,1 @@
+<weather>

--- a/locale/nl-NL/wikihow.intent
+++ b/locale/nl-NL/wikihow.intent
@@ -1,0 +1,3 @@
+(zoek|zoek op|vind) {query} op (wiki how|wikihow)
+zoek (wiki how|wikihow) (naar|) {query}
+wat zegt (wiki how|wikihow) over {query}

--- a/locale/pt-BR/howto.failure.dialog
+++ b/locale/pt-BR/howto.failure.dialog
@@ -1,0 +1,3 @@
+não tenho certeza
+não sei
+tentei pesquisar no wikihow mas não encontrei nada

--- a/locale/pt-BR/howto.intent
+++ b/locale/pt-BR/howto.intent
@@ -1,0 +1,9 @@
+(explique|) passo a passo {query}
+(como eu posso|como você) {query}
+(como|me mostre como|me diga como) {query}
+(passos|instruções) para {query}
+quais são os passos para {query}
+(pode|poderia) você [por favor] me dizer como {query}
+(pode|poderia) você [por favor] explicar como {query}
+[por favor] me mostre como {query}
+eu (quero|preciso) (saber|aprender) como {query}

--- a/locale/pt-BR/misc_blacklist.voc
+++ b/locale/pt-BR/misc_blacklist.voc
@@ -1,0 +1,8 @@
+você pode
+explicar
+quanto tempo
+instalar
+é isso
+habilidades
+que horas
+você faz

--- a/locale/pt-BR/query.blacklist
+++ b/locale/pt-BR/query.blacklist
@@ -1,0 +1,2 @@
+(isso|isto|estas|esses|esse|aquilo|um)
+(ele|ela|eles|elas|dele|dela|deles|delas)

--- a/locale/pt-BR/skill.json
+++ b/locale/pt-BR/skill.json
@@ -1,0 +1,13 @@
+{
+  "skill_id": "ovos-skill-wikihow.openvoiceos",
+  "source": "https://github.com/OpenVoiceOS/ovos-skill-wikihow",
+  "name": "WikiHow",
+  "description": "Como fazer quase tudo.",
+  "examples": [
+    "como cozinhar um ovo",
+    "como faço meu cachorro parar de latir"
+  ],
+  "tags": [
+    "diário", "informação"
+  ]
+}

--- a/locale/pt-BR/step.dialog
+++ b/locale/pt-BR/step.dialog
@@ -1,0 +1,1 @@
+Passo {number}, {step}

--- a/locale/pt-BR/weather.voc
+++ b/locale/pt-BR/weather.voc
@@ -1,0 +1,2 @@
+meteorologia
+clima

--- a/locale/pt-BR/wikihow.blacklist
+++ b/locale/pt-BR/wikihow.blacklist
@@ -1,0 +1,1 @@
+<weather>

--- a/locale/pt-BR/wikihow.intent
+++ b/locale/pt-BR/wikihow.intent
@@ -1,0 +1,3 @@
+(pesquisar|procurar|buscar) {query} no (wiki how|wikihow)
+pesquisar (wiki how|wikihow) (por|) {query}
+o que o (wiki how|wikihow) (diz|pensa) sobre {query}

--- a/locale/sv-SE/howto.failure.dialog
+++ b/locale/sv-SE/howto.failure.dialog
@@ -1,0 +1,3 @@
+jag är inte säker
+jag vet inte
+jag försökte söka på wikihow men hittade ingenting

--- a/locale/sv-SE/howto.intent
+++ b/locale/sv-SE/howto.intent
@@ -1,0 +1,9 @@
+(förklara|) steg för steg {query}
+(hur kan|gör|skulle) jag {query}
+(hur|visa mig hur|berätta hur) jag {query}
+(steg|instruktioner) för att {query}
+vilka är stegen för att {query}
+(kan|skulle) du [snälla] berätta hur jag {query}
+(kan|skulle) du [snälla] förklara hur man {query}
+[snälla] visa mig hur jag {query}
+jag (vill|behöver) (veta|lära mig) hur jag {query}

--- a/locale/sv-SE/misc_blacklist.voc
+++ b/locale/sv-SE/misc_blacklist.voc
@@ -1,0 +1,8 @@
+kan du
+förklara
+hur länge
+installera
+är det
+färdigheter
+vad är klockan
+gör du

--- a/locale/sv-SE/query.blacklist
+++ b/locale/sv-SE/query.blacklist
@@ -1,0 +1,2 @@
+(det|detta|denna|dessa|den|en)
+(han|hon|de|honom|henne|dem|hans|hennes)

--- a/locale/sv-SE/skill.json
+++ b/locale/sv-SE/skill.json
@@ -1,0 +1,13 @@
+{
+  "skill_id": "ovos-skill-wikihow.openvoiceos",
+  "source": "https://github.com/OpenVoiceOS/ovos-skill-wikihow",
+  "name": "WikiHow",
+  "description": "Hur man gör nästan allt.",
+  "examples": [
+    "hur kokar man ett ägg",
+    "hur får jag min hund att sluta skälla"
+  ],
+  "tags": [
+    "dagligt", "information"
+  ]
+}

--- a/locale/sv-SE/step.dialog
+++ b/locale/sv-SE/step.dialog
@@ -1,0 +1,1 @@
+Steg {number}, {step}

--- a/locale/sv-SE/weather.voc
+++ b/locale/sv-SE/weather.voc
@@ -1,0 +1,2 @@
+meteorologi
+väder

--- a/locale/sv-SE/wikihow.blacklist
+++ b/locale/sv-SE/wikihow.blacklist
@@ -1,0 +1,1 @@
+<weather>

--- a/locale/sv-SE/wikihow.intent
+++ b/locale/sv-SE/wikihow.intent
@@ -1,0 +1,3 @@
+(sök|slå upp|hitta) {query} på (wiki how|wikihow)
+sök på (wiki how|wikihow) (efter|) {query}
+vad säger (wiki how|wikihow) om {query}


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 4.8 (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

Adds the pt-BR, nl-NL, sv-SE, and kab locale directories, translated from the en-US reference set (9 files each: dialog, intent, voc, blacklist, skill.json).

These lines were written by a machine; fix or delete any line a speaker would not say.

Low-confidence locale: kab. Written short and literal since no native reviewer produced it.

Proofs:

- File-set parity (comm -3 against en-US, empty output for all four).
- padacioso: every new `.intent` file's lines expand successfully via `ovos_spec_tools.expansion.expand`.
  - pt-BR: 2 intent files, 12 lines, 0 errors
  - nl-NL: 2 intent files, 12 lines, 0 errors
  - sv-SE: 2 intent files, 12 lines, 0 errors
  - kab: 2 intent files, 12 lines, 0 errors
- No existing locale file touched: `git diff origin/dev --name-only | grep -vE 'locale/(pt-BR|nl-NL|sv-SE|kab)/'` prints nothing.
- `git diff origin/dev --stat` tail: 36 files changed, 168 insertions(+)


**Parity after this PR**

4 of 13 locales have exactly the en-US file set.
The locales added by this PR (pt-BR, nl-NL, sv-SE, kab) are complete.
All of ca-ES, da-DK, de-DE, es-ES, eu-ES, fr-FR, gl-ES, it-IT, pt-PT lack query.blacklist.
- da-DK: lacks misc_blacklist.voc, weather.voc, wikihow.blacklist
- eu-ES: lacks misc_blacklist.voc, skill.json, weather.voc, wikihow.blacklist
- gl-ES: lacks misc_blacklist.voc, weather.voc, wikihow.blacklist
- it-IT: lacks misc_blacklist.voc, skill.json, weather.voc, wikihow.blacklist
- pt-PT: lacks misc_blacklist.voc, skill.json, weather.voc, wikihow.blacklist
Files missing from locales that existed before this PR are left for a follow-up; nothing existing was edited.
